### PR TITLE
Converted fail and warning to use the Enum

### DIFF
--- a/pydantic_sarif/model.py
+++ b/pydantic_sarif/model.py
@@ -1683,10 +1683,10 @@ class Result(BaseModel):
         description='A reference used to locate the rule descriptor relevant to this result.',
     )
     kind: Optional[Kind] = Field(
-        'fail', description='A value that categorizes results by evaluation state.'
+        Kind.fail, description='A value that categorizes results by evaluation state.'
     )
     level: Optional[Level] = Field(
-        'warning', description='A value specifying the severity level of the result.'
+        Level.warning, description='A value specifying the severity level of the result.'
     )
     message: Message = Field(
         ...,


### PR DESCRIPTION
Pydantic was complaining that it expected an Enum but was getting a str.  Found that results was using the strings 'fail' and 'warning' instead of Kind.fail and Level.warning